### PR TITLE
Resolve namespace issues

### DIFF
--- a/lib/generators/active_record/magnetik_generator.rb
+++ b/lib/generators/active_record/magnetik_generator.rb
@@ -3,7 +3,7 @@ require 'rails/generators/active_record'
 module ActiveRecord
   module Generators
     class MagnetikGenerator < ActiveRecord::Generators::Base
-      include Rails::Generators::Migration
+      include ::Rails::Generators::Migration
 
       source_root File.expand_path('../templates', __FILE__)
 

--- a/lib/generators/magnetik/install/install_generator.rb
+++ b/lib/generators/magnetik/install/install_generator.rb
@@ -2,8 +2,8 @@ require 'rails/generators/active_record'
 
 module Magnetik
   module Generators
-    class InstallGenerator < Rails::Generators::Base
-      include Rails::Generators::Migration
+    class InstallGenerator < ::Rails::Generators::Base
+      include ::Rails::Generators::Migration
 
       source_root File.expand_path('../templates', __FILE__)
 

--- a/lib/generators/magnetik/magnetik_generator.rb
+++ b/lib/generators/magnetik/magnetik_generator.rb
@@ -2,8 +2,8 @@ require 'rails/generators/named_base'
 
 module Magnetik
   module Generators
-    class MagnetikGenerator < Rails::Generators::NamedBase
-      include Rails::Generators::ResourceHelpers
+    class MagnetikGenerator < ::Rails::Generators::NamedBase
+      include ::Rails::Generators::ResourceHelpers
 
       namespace "magnetik"
       source_root File.expand_path('../templates', __FILE__)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,3 +19,12 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
 end
+
+
+# Shoulda Matchers setup
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
Fixes #2

It appears that newer rails versions have issues resolving namespaces within generators that do not begin with the ::
